### PR TITLE
return gnuplot table

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,3 +3,5 @@ require 'torch'
 gnuplot = {}
 include('gnuplot.lua')
 include('hist.lua')
+
+return gnuplot


### PR DESCRIPTION
local gnuplot = require('gnuplot')

returns a boolean rather than the package table.