### PR TITLE
change gnuplot.plot format string

### DIFF
--- a/gnuplot.lua
+++ b/gnuplot.lua
@@ -588,9 +588,8 @@ local function gnuplot_string(legend,x,y,format)
       elseif f == '~' or f == 'csplines' then return 'smooth csplines'
       elseif f == 'acsplines' then return 'smooth acsplines'
       elseif f == 'V' or f == 'v' or f == 'vectors' then vecplot[i]=true;return 'with vectors'
-      else return 'with ' .. f
+      else return f
       end
-      error("format string accepted: '.' or '-' or '+' or '+-' or '~' or '~ COEF'")
    end
    for i=1,#legend do
       if i > 1 then hstr = hstr .. ' , ' end


### PR DESCRIPTION
Now the gnuplot.plot can take Gnuplot format command as input. For example, 

gnuplot.plot({'legend',x,y,'axis x1y2 with points pointtype 7 pointsize 0.1'})

Remove format error detection because it's useless