### PR TITLE
Added fix for silent failure when output file is in nonexistent dir.

### DIFF
--- a/gnuplot.lua
+++ b/gnuplot.lua
@@ -732,6 +732,18 @@ local function filefigure(fname,term,n)
    if not _gptable.hasrefresh then
       print('Plotting to files is disabled in gnuplot 4.2, install gnuplot 4.4')
    end
+
+   -- Check whether the output directory can be written to here - torch.PipeFile
+   -- has no read/write option so we can't read back any error messages from
+   -- gnuplot, and writing to 'non_existent_dir/plot.png' fails silently.
+   local outputDir = paths.dirname(fname)
+   if outputDir == '' then
+      outputDir = '.'
+   end
+   if not paths.dirp(outputDir) then
+      error('cannot save to ' .. fname .. ': directory does not exist')
+   end
+
    local gp = getfigure(n)
    gp.fname = fname
    gp.term = term

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,52 @@
+require 'gnuplot'
+require 'os'
+require 'paths'
+require 'torch'
+
+local tester = torch.Tester()
+local tests = {}
+
+-- Returns a random string of lowercase digits
+local function randomFilenameStr()
+   local t = {}
+   for i = 1, 10 do
+      table.insert(t, string.char(math.random(97, 122)))
+   end
+   return table.concat(t)
+end
+
+-- Make sure we can write to a new filename, but not to a nonexistent directory.
+function tests.cannotWriteToNonExistentDir()
+   -- Save locally, this should work
+   local validFilename = randomFilenameStr() .. '.png'
+
+   -- If this already exists (bad luck!), don't let the test overwrite it
+   assert(not (paths.filep(validFilename) or
+               paths.dirp(validFilename)),
+          'random filename aready exists (?)')
+
+   -- Should work fine
+   gnuplot.pngfigure(validFilename)
+   gnuplot.plot({'Sin Curve',torch.sin(torch.linspace(-5,5))})
+   gnuplot.plotflush()
+
+   -- Clean up after ourselves
+   os.remove(validFilename)
+
+   -- Now make an invalid output
+   local nonExistentDir = randomFilenameStr()
+   assert(not (paths.filep(nonExistentDir) or
+               paths.dirp(nonExistentDir)),
+          'random dir aready exists (?)')
+
+   -- This makes an absolute path below cwd, seems Lua has no way (?) to query
+   -- the file separator charater by itself...
+   local invalidFilename = paths.concat(nonExistentDir, validFilename)
+   local function shouldCrash()
+      gnuplot.pngfigure(invalidFilename)
+   end
+   tester:assertErrorPattern(shouldCrash, 'directory does not exist')
+end
+
+tester:add(tests)
+return tester:run()


### PR DESCRIPTION
Previously if you say 'gnuplot.pngfigure("nonexistent_dir/foo.png")'
this would silently fail - an error message is generated in gnuplot but
we cannot read anything back via the readonly PipeFile. We now treat
this as an error if trying to write to a nonexistent directory.