### PR TITLE
add logscale support on y-axis

### DIFF
--- a/gnuplot.lua
+++ b/gnuplot.lua
@@ -908,6 +908,19 @@ function gnuplot.grid(toggle)
       refreshCurrent()
    end
 end
+function gnuplot.logscale(toggle)
+   if not _gptable.hasrefresh then
+      print('gnuplot.logscale disabled')
+      return
+   end
+   if toggle then
+      writeToCurrent('set logscale y')
+      refreshCurrent()
+   else
+      writeToCurrent('unset logscale y')
+      refreshCurrent()
+   end
+end
 function gnuplot.movelegend(hloc,vloc)
    if not _gptable.hasrefresh then
       print('gnuplot.movelegend disabled')


### PR DESCRIPTION
@soumith I added this option because I'm using it with "Logger.lua" (from torch/optim), so if you are interested I can also create a pull request with the corresponding "Logger.lua" changes